### PR TITLE
fix: use email for user folder

### DIFF
--- a/src/lib/igor-setup.ts
+++ b/src/lib/igor-setup.ts
@@ -200,7 +200,7 @@ export class IgorSetup {
 
     const licenseFile = fs.readFileSync(licenseFileDir, "utf-8");
     const licenseFileContent = plist.parse(licenseFile) as any;
-    const userName = licenseFileContent.name.split("@")[0];
+    const userName = licenseFileContent.email.split("@")[0];
     const id = licenseFileContent.id;
     this.userName = `${userName}_${id}`;
     const newUserDir = path.join(this.workingDir, "gm-user", this.userName);


### PR DESCRIPTION
The first part of the user's email is now used as the user folder name, matching GameMaker, and removing any issues related to spaces in the folder name.